### PR TITLE
fix other ts error to correct compiling

### DIFF
--- a/src/components/AutocompleteField/AutoCompleteField.tsx
+++ b/src/components/AutocompleteField/AutoCompleteField.tsx
@@ -267,7 +267,7 @@ export function AutoCompleteField<T extends any, U extends any>(props: IAutoComp
                 // Disable highlighting, since we used empty string search
                 enableHighlighting = false;
                 // Put selected item at the top if it is not in the result list
-                if (itemIndexOf(emptyStringResults, selectedItem) === -1) {
+                if (!!selectedItem && itemIndexOf(emptyStringResults, selectedItem) === -1) {
                     result = [selectedItem, ...emptyStringResults];
                 } else {
                     result = emptyStringResults;


### PR DESCRIPTION
prevents TS error `Argument of type 'T | undefined' is not assignable to parameter of type 'T'`.