### PR TITLE
Bugfix: improve Accordion and CodeEditor (CMEM 3067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+* allow children of <Accordion /> item to get calculated based on their DOM sizes
+
 ## [22.1.0] - 2022-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 * allow children of <Accordion /> item to get calculated based on their DOM sizes
+* add borders to CodeMirror editor area and include display of focused state
+
+# Changed
+
+* move style imports of CodeMirror layout to `extensions`
 
 ## [22.1.0] - 2022-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+* `<CodeEditor />` element based on `CodeMirror` library, supporting Markdown, Python, Sparql, SQL, Turtle and XML syntax
+
 ### Fixed
 
 * allow children of <Accordion /> item to get calculated based on their DOM sizes

--- a/src/components/Accordion/accordion.scss
+++ b/src/components/Accordion/accordion.scss
@@ -32,9 +32,16 @@
 .#{$prefix}--accordion__content {
     padding: $eccgui-size-block-whitespace / 2;
     margin: 0 calc(1rem + #{$eccgui-size-block-whitespace / 2}) 0 $eccgui-size-block-whitespace / 2;
+    display: block;
+    opacity: 0;
+    position: fixed;
+    left: -5000em;
 
     .#{$prefix}--accordion__item--active & {
         padding: $eccgui-size-block-whitespace / 2 $eccgui-size-block-whitespace / 2 $eccgui-size-block-whitespace $eccgui-size-block-whitespace / 2;
+        opacity: 1;
+        position: static;
+        left: auto;
     }
 
     .#{$prefix}--accordion--start & {
@@ -47,6 +54,9 @@
 
     *, *::before, *::after {
         box-sizing: inherit;
+    }
+    .CodeMirror-scroll, .CodeMirror-sizer, .CodeMirror-gutter, .CodeMirror-gutters, .CodeMirror-linenumber {
+        box-sizing: content-box;
     }
 }
 

--- a/src/components/Accordion/accordion.scss
+++ b/src/components/Accordion/accordion.scss
@@ -55,9 +55,6 @@
     *, *::before, *::after {
         box-sizing: inherit;
     }
-    .CodeMirror-scroll, .CodeMirror-sizer, .CodeMirror-gutter, .CodeMirror-gutters, .CodeMirror-linenumber {
-        box-sizing: content-box;
-    }
 }
 
 .#{$eccgui}-accordion__item--elevated {

--- a/src/extensions/_index.scss
+++ b/src/extensions/_index.scss
@@ -1,1 +1,2 @@
 @import "./react-flow/react-flow";
+@import "./codemirror/codemirror";

--- a/src/extensions/_index.scss
+++ b/src/extensions/_index.scss
@@ -1,2 +1,6 @@
 @import "./react-flow/react-flow";
+/*
+CodeMirror styles are already included by the base component styles
+because it is used as lib for elements there already. 
 @import "./codemirror/codemirror";
+*/

--- a/src/extensions/codemirror/CodeMirror.stories.tsx
+++ b/src/extensions/codemirror/CodeMirror.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { CodeEditor } from "./CodeMirror";
+
+export default {
+    title: "Extensions/CodeEditor",
+    component: CodeEditor,
+    //parameters: { actions: { argTypesRegex: '^on.*' } },
+    argTypes: {
+        onChange: {
+            action: "value changed"
+        }
+    },
+} as ComponentMeta<typeof CodeEditor>;
+
+const TemplateFull: ComponentStory<typeof CodeEditor> = (args) => (
+    <CodeEditor {...args} />
+);
+
+export const BasicExample = TemplateFull.bind({});
+BasicExample.args = {
+    name: "codeinput",
+    mode: "markdown",
+    defaultValue: "**test me**",
+};

--- a/src/extensions/codemirror/CodeMirror.tsx
+++ b/src/extensions/codemirror/CodeMirror.tsx
@@ -8,55 +8,72 @@ import "codemirror/mode/turtle/turtle.js";
 import "codemirror/mode/xml/xml.js";
 
 export interface CodeEditorProps {
+    /**
+     * `name` attribute of connected textarea element.
+     */
     name: string;
+    /**
+     * `id` attribute of connected textarea element.
+     * If not set then the default value is created by `codemirror-${name-attribute}`.
+     */
     id?: string;
+    /**
+     * Handler method to receive onChange events.
+     * As input the new value is given.
+     */
     onChange: (v: any) => void;
+    /**
+     * Syntax mode of the code editor.
+     */
     mode?: "markdown" | "python" | "sparql" | "sql" | "turtle" | "xml" | "undefined";
+    /**
+     * Default value used first when the editor is instanciated.
+     */
     defaultValue?: any;
 }
 
 /**
  * Includes a code editor, currently we use CodeMirror library as base.
  */
-const CodeEditor = ({
+export const CodeEditor = ({
     onChange,
     name,
     id,
     mode = "undefined",
     defaultValue
 }: CodeEditorProps) => {
-    const ref = useRef<HTMLTextAreaElement>(null);
+    const domRef = useRef<HTMLTextAreaElement>(null);
 
     useEffect(() => {
-        if (onChange !== undefined && ref.current) {
-            const editorInstance = CodeMirror.fromTextArea(ref.current, {
-                mode: mode === "undefined" ? undefined : mode,
-                lineWrapping: true,
-                lineNumbers: true,
-                tabSize: 2,
-                theme: "xq-light",
-            });
+        const editorInstance = CodeMirror.fromTextArea(domRef.current!, {
+            mode: mode === "undefined" ? undefined : mode,
+            lineWrapping: true,
+            lineNumbers: true,
+            tabSize: 2,
+            theme: "xq-light",
+        });
 
-            editorInstance.on("change", (api) => {
-                onChange(api.getValue());
-            });
-        }
+        editorInstance.on("change", (api) => {
+            onChange(api.getValue());
+        });
+
+        return function cleanup() {
+            editorInstance.toTextArea();
+        };
     }, [onChange, mode]);
 
     return (
         <textarea
+            ref={domRef}
             /**
              * FIXME: same `data-test-id` for multiple code editor elements are valid
              * but may not make really sense for testing purposes. Currently let it
              * unchanged from the code what was took over here.
              */
             data-test-id="codemirror-wrapper"
-            ref={ref}
-            id={id??`codemirror-${name}`}
+            id={!!id ? id : `codemirror-${name}`}
             name={name}
             defaultValue={defaultValue}
         />
     );
 }
-
-export default CodeEditor;

--- a/src/extensions/codemirror/CodeMirror.tsx
+++ b/src/extensions/codemirror/CodeMirror.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef } from "react";
+import CodeMirror from "codemirror";
+import "codemirror/mode/markdown/markdown.js";
+import "codemirror/mode/python/python.js";
+import "codemirror/mode/sparql/sparql.js";
+import "codemirror/mode/sql/sql.js";
+import "codemirror/mode/turtle/turtle.js";
+import "codemirror/mode/xml/xml.js";
+
+export interface CodeEditorProps {
+    name: string;
+    id?: string;
+    onChange: (v: any) => void;
+    mode?: "markdown" | "python" | "sparql" | "sql" | "turtle" | "xml" | "undefined";
+    defaultValue?: any;
+}
+
+/**
+ * Includes a code editor, currently we use CodeMirror library as base.
+ */
+const CodeEditor = ({
+    onChange,
+    name,
+    id,
+    mode = "undefined",
+    defaultValue
+}: CodeEditorProps) => {
+    const ref = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        if (onChange !== undefined && ref.current) {
+            const editorInstance = CodeMirror.fromTextArea(ref.current, {
+                mode: mode === "undefined" ? undefined : mode,
+                lineWrapping: true,
+                lineNumbers: true,
+                tabSize: 2,
+                theme: "xq-light",
+            });
+
+            editorInstance.on("change", (api) => {
+                onChange(api.getValue());
+            });
+        }
+    }, [onChange, mode]);
+
+    return (
+        <textarea
+            /**
+             * FIXME: same `data-test-id` for multiple code editor elements are valid
+             * but may not make really sense for testing purposes. Currently let it
+             * unchanged from the code what was took over here.
+             */
+            data-test-id="codemirror-wrapper"
+            ref={ref}
+            id={id??`codemirror-${name}`}
+            name={name}
+            defaultValue={defaultValue}
+        />
+    );
+}
+
+export default CodeEditor;

--- a/src/extensions/codemirror/CodeMirror.tsx
+++ b/src/extensions/codemirror/CodeMirror.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import CodeMirror from "codemirror";
+import { CLASSPREFIX as eccgui } from "../../configuration/constants";
 import "codemirror/mode/markdown/markdown.js";
 import "codemirror/mode/python/python.js";
 import "codemirror/mode/sparql/sparql.js";
@@ -63,17 +64,19 @@ export const CodeEditor = ({
     }, [onChange, mode]);
 
     return (
-        <textarea
-            ref={domRef}
-            /**
-             * FIXME: same `data-test-id` for multiple code editor elements are valid
-             * but may not make really sense for testing purposes. Currently let it
-             * unchanged from the code what was took over here.
-             */
-            data-test-id="codemirror-wrapper"
-            id={!!id ? id : `codemirror-${name}`}
-            name={name}
-            defaultValue={defaultValue}
-        />
+        <div className={`${eccgui}-codeeditor`}>
+            <textarea
+                ref={domRef}
+                /**
+                 * FIXME: same `data-test-id` for multiple code editor elements are valid
+                 * but may not make really sense for testing purposes. Currently let it
+                 * unchanged from the code what was took over here.
+                 */
+                data-test-id="codemirror-wrapper"
+                id={!!id ? id : `codemirror-${name}`}
+                name={name}
+                defaultValue={defaultValue}
+            />
+        </div>
     );
 }

--- a/src/extensions/codemirror/_codemirror.scss
+++ b/src/extensions/codemirror/_codemirror.scss
@@ -3,22 +3,24 @@
 
 // adjustments
 
-.CodeMirror {
-    border-radius: $pt-border-radius;
+.#{$eccgui}-codeeditor {
+    .CodeMirror {
+        border-radius: $pt-border-radius;
 
-    // get them a "border" like input boxes from blueprintjs
-    box-shadow: input-transition-shadow($input-shadow-color-focus), $pt-input-box-shadow;
-    &.CodeMirror-focused {
-        box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
-    }
+        // get them a "border" like input boxes from blueprintjs
+        box-shadow: input-transition-shadow($input-shadow-color-focus), $pt-input-box-shadow;
+        &.CodeMirror-focused {
+            box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+        }
 
-    .CodeMirror-gutters {
-        // allow "borders" to shine through
-        background-color: rgba(0,0,0,0.05);
-    }
+        .CodeMirror-gutters {
+            // allow "borders" to shine through
+            background-color: rgba(0,0,0,0.05);
+        }
 
-    .CodeMirror-scroll {
-        cursor: text;
+        .CodeMirror-scroll {
+            cursor: text;
+        }
     }
 }
 

--- a/src/extensions/codemirror/_codemirror.scss
+++ b/src/extensions/codemirror/_codemirror.scss
@@ -1,0 +1,23 @@
+@import "~codemirror/lib/codemirror.css";
+@import "~codemirror/theme/xq-light.css";
+
+// adjustments
+
+.CodeMirror {
+    border-radius: $pt-border-radius;
+
+    // get them a "border" like input boxes from blueprintjs
+    box-shadow: input-transition-shadow($input-shadow-color-focus), $pt-input-box-shadow;
+    &.CodeMirror-focused {
+        box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+    }
+
+    .CodeMirror-gutters {
+        // allow "borders" to shine through
+        background-color: rgba(0,0,0,0.05);
+    }
+
+    .CodeMirror-scroll {
+        cursor: text;
+    }
+}

--- a/src/extensions/codemirror/_codemirror.scss
+++ b/src/extensions/codemirror/_codemirror.scss
@@ -21,3 +21,9 @@
         cursor: text;
     }
 }
+
+.#{$prefix}--accordion__content {
+    .CodeMirror-scroll, .CodeMirror-sizer, .CodeMirror-gutter, .CodeMirror-gutters, .CodeMirror-linenumber {
+        box-sizing: content-box;
+    }
+}

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,4 +1,2 @@
-import CodeEditor from "./codemirror/CodeMirror";
-
-export { CodeEditor };
+export * from "./codemirror/CodeMirror";
 export * from "./react-flow";

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,0 +1,4 @@
+import CodeEditor from "./codemirror/CodeMirror";
+
+export { CodeEditor };
+export * from "./react-flow";

--- a/src/index.scss
+++ b/src/index.scss
@@ -130,10 +130,6 @@
 // currently not needed @import '~carbon-components/scss/components/pagination-nav/pagination-nav';
 // used in own component @import '~carbon-components/scss/components/ui-shell/ui-shell'; // experimental
 
-// other 3rd party libs
-@import "~codemirror/lib/codemirror.css";
-@import "~codemirror/theme/xq-light.css";
-
 // == Load element styles ======================================================
 
 @import "./components/Typography/typography";

--- a/src/index.scss
+++ b/src/index.scss
@@ -166,6 +166,7 @@
 @import "./components/PropertyValuePair/propertyvalue";
 @import "./components/Iframe/iframe";
 @import "./components/AutoSuggestion/AutoSuggestion";
+@import "./extensions/codemirror/codemirror";
 
 // == load tweaks ==============================================================
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,4 +250,4 @@ export {
 };
 
 export * from "./cmem";
-export * from "./extensions/react-flow";
+export * from "./extensions";


### PR DESCRIPTION
* adjust how `Accordion` items are hidden, so that children elements actually can render in DOM and do math on their elements
* adjust `CodeMirror` imports, correct its display styles
* provide `CodeEditor` element