### PR TITLE
CMEM-5711 - reset options in MultiSuggestField when query is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 -   new icons: `state-locked`, `state-unlocked`, `application-notification`
 -   new use hook
     -   `useApplicationHeaderOverModals`: forces the application header to be displayed over modal backgrounds
--   `<CodeMirror />`: 
+-   `<CodeMirror />`:
     -   Added support for N-triples and Mathematica modes.
     -   Allow direct access to the underlying code mirror instance.
     -   Allow to register a scroll handler.
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 -   `<TagList />`
     -   vertical alignment fixed in nowrap containers and for tags with icons
+-   `<MultiSelect />`
+    -   reset the list of options when the query is cleared but nothing from the list is selected
+    -   add the created element to the list of filtered elements immediately after its creation
 
 ### Changed
 

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -193,7 +193,7 @@ export function MultiSelect<T>({
     React.useEffect(() => {
         setItemsCopy([...items, ...createdItems]);
         setFilteredItemList([...items, ...createdItems]);
-    }, [items.map((item) => itemId(item)).join("|"), createdItems.map((item) => itemId(item)).join("|")]);
+    }, [items.map((item) => itemId(item)).join("|")]);
 
     React.useEffect(() => {
         onSelection &&
@@ -284,6 +284,10 @@ export function MultiSelect<T>({
                 }
             };
             requestState.current.timeoutId = window.setTimeout(fn, requestDelay && requestDelay > 0 ? requestDelay : 0);
+        } else if (!query.length) {
+            // if the query is empty we need to show all options and reset current query
+            requestState.current.query = "";
+            setFilteredItemList(() => [...itemsCopy, ...createdItems]);
         }
     };
 
@@ -342,6 +346,7 @@ export function MultiSelect<T>({
         //set new items
         setCreatedItems((items) => [...items, newItem]);
         setCreatedSelectedItems((items) => [...items, newItem]);
+        setFilteredItemList((items) => [...items, newItem]);
         requestState.current.query = "";
         return newItem;
     };

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -412,7 +412,7 @@ export function MultiSelect<T>({
             <IconButton
                 disabled={disabled}
                 name="operation-clear"
-                data-testid="clear-all-items"
+                data-test-id="clear-all-items"
                 onClick={handleClear}
             />
         ) : undefined;

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -412,7 +412,7 @@ export function MultiSelect<T>({
             <IconButton
                 disabled={disabled}
                 name="operation-clear"
-                data-test-id="clear-all-items"
+                data-testid="clear-all-items"
                 onClick={handleClear}
             />
         ) : undefined;

--- a/src/components/MultiSuggestField/MultiSuggestField.stories.tsx
+++ b/src/components/MultiSuggestField/MultiSuggestField.stories.tsx
@@ -56,6 +56,7 @@ dropdownOnFocus.args = {
     prePopulateWithItems: false,
     itemId: (item) => item.testId,
     itemLabel: (item) => item.testLabel,
+    noResultText: "No result.",
 };
 
 const selectedItems = items.slice(1, 3);
@@ -69,7 +70,7 @@ predefinedValues.args = {
     selectedItems,
     prePopulateWithItems: false,
     itemId: (item) => item.testId,
-    itemLabel: (item) => item.testLabel,
+    itemLabel: (item) => <span data-testid={`${item.testLabel.trim()}`}>{item.testLabel}</span>,
 };
 
 /**

--- a/src/components/MultiSuggestField/tests/MultiSuggestField.test.tsx
+++ b/src/components/MultiSuggestField/tests/MultiSuggestField.test.tsx
@@ -28,13 +28,21 @@ describe("MultiSuggestField", () => {
     });
 
     it("should clear all selected items on clear button click", async () => {
-        const { queryByTestId, getByTestId } = render(<MultiSuggestField {...predefinedValues.args} />);
+        const { queryByTestId, container } = render(<MultiSuggestField {...predefinedValues.args} />);
 
-        const clearButton = getByTestId("clear-all-items");
-        fireEvent.click(clearButton);
+        const [firstSelected, secondSelected]: Array<string> = predefinedValues.args.selectedItems.map(
+            ({ testLabel }) => testLabel.trim()
+        );
+
+        const clearButton = container.querySelector('[data-test-id="clear-all-items"');
+
+        expect(clearButton).toBeInTheDocument();
+
+        fireEvent.click(clearButton!);
 
         await waitFor(() => {
-            expect(queryByTestId("selected-item")).not.toBeInTheDocument();
+            expect(queryByTestId(firstSelected)).not.toBeInTheDocument();
+            expect(queryByTestId(secondSelected)).not.toBeInTheDocument();
         });
     });
 

--- a/src/components/MultiSuggestField/tests/MultiSuggestField.test.tsx
+++ b/src/components/MultiSuggestField/tests/MultiSuggestField.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import "@testing-library/jest-dom";
+
+import { MultiSuggestField } from "../MultiSuggestField";
+import { Default, dropdownOnFocus, predefinedValues } from "../MultiSuggestField.stories";
+
+describe("MultiSuggestField", () => {
+    it("should render default input", () => {
+        const { container } = render(<MultiSuggestField {...Default.args} />);
+        const [input] = container.getElementsByClassName("eccgui-multiselect");
+
+        expect(input).toBeInTheDocument();
+    });
+
+    it("should render default selected items", async () => {
+        const { getByTestId } = render(<MultiSuggestField {...predefinedValues.args} />);
+
+        const [firstSelected, secondSelected]: Array<string> = predefinedValues.args.selectedItems.map(
+            ({ testLabel }) => testLabel.trim()
+        );
+
+        await waitFor(() => {
+            expect(getByTestId(firstSelected)).toBeInTheDocument();
+            expect(getByTestId(secondSelected)).toBeInTheDocument();
+        });
+    });
+
+    it("should clear all selected items on clear button click", async () => {
+        const { queryByTestId, getByTestId } = render(<MultiSuggestField {...predefinedValues.args} />);
+
+        const clearButton = getByTestId("clear-all-items");
+        fireEvent.click(clearButton);
+
+        await waitFor(() => {
+            expect(queryByTestId("selected-item")).not.toBeInTheDocument();
+        });
+    });
+
+    it("should filter options and reset them if the query is empty", async () => {
+        const { container } = render(<MultiSuggestField {...dropdownOnFocus.args} />);
+
+        const [inputContainer] = container.getElementsByClassName("eccgui-multiselect");
+        const [input] = inputContainer.getElementsByTagName("input");
+
+        fireEvent.click(input);
+
+        await waitFor(() => {
+            const listbox = screen.getByRole("listbox");
+            expect(listbox).toBeInTheDocument();
+
+            const menuItems = listbox.getElementsByClassName("eccgui-menu__item");
+            expect(menuItems.length).toBe(dropdownOnFocus.args.items.length);
+        });
+
+        fireEvent.change(input, { target: { value: "ex" } });
+
+        await waitFor(() => {
+            const listbox = screen.getByRole("listbox");
+            const menuItems = listbox.getElementsByClassName("eccgui-menu__item");
+
+            expect(menuItems.length).toBe(1);
+
+            const noResult = screen.queryByText(dropdownOnFocus.args.noResultText);
+            expect(noResult).not.toBeInTheDocument();
+        });
+
+        fireEvent.change(input, { target: { value: "ttt" } });
+
+        await waitFor(() => {
+            const listbox = screen.getByRole("listbox");
+            const menuItems = listbox.getElementsByClassName("eccgui-menu__item");
+
+            expect(menuItems.length).toBe(1);
+
+            const noResult = screen.queryByText(dropdownOnFocus.args.noResultText);
+            expect(noResult).toBeInTheDocument();
+        });
+
+        fireEvent.change(input, { target: { value: "" } });
+
+        await waitFor(() => {
+            const listbox = screen.getByRole("listbox");
+            const menuItems = listbox.getElementsByClassName("eccgui-menu__item");
+            expect(menuItems.length).toBe(dropdownOnFocus.args.items.length);
+        });
+    });
+});


### PR DESCRIPTION
Added options reset when the query is empty.
Setting a created item in the list of filtered items after its creation.