### PR TITLE
bugfix: centered header-menu items in <NodeContent />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     -   `<GridColumn />`
     -   `<PropertyName />` and `<PropertyValue />`
 
+### Fixed
+
+-   Centered header-menu items in <NodeContent />
+
 ## [25.0.0] - 2025-12-01
 
 This is a major release, and it might be not compatible with your current usage of our library. Please read about the necessary changes in the section about how to migrate.

--- a/src/extensions/react-flow/nodes/_nodes.scss
+++ b/src/extensions/react-flow/nodes/_nodes.scss
@@ -53,7 +53,8 @@
     border-radius: $reactflow-node-border-radius;
 
     &:hover {
-        box-shadow: 0 0 0 6 * $reactflow-node-border-width eccgui-color-rgba($reactflow-edge-stroke-color-selected, 0.05);
+        box-shadow: 0 0 0 6 * $reactflow-node-border-width
+            eccgui-color-rgba($reactflow-edge-stroke-color-selected, 0.05);
     }
 
     &.was-resized.is-resizable-vertical {
@@ -147,8 +148,10 @@
 
 .#{$eccgui}-graphviz__node__header-depiction,
 .#{$eccgui}-graphviz__node__header-menu {
+    display: flex;
     flex-grow: 0;
     flex-shrink: 0;
+    align-items: center;
     max-height: calc(#{$reactflow-node-basesize} - #{2 * $reactflow-node-border-width});
     margin: 0 $eccgui-size-block-whitespace * 0.25;
 
@@ -158,8 +161,6 @@
 }
 
 .#{$eccgui}-graphviz__node__header-depiction {
-    display: flex;
-    align-items: center;
     justify-content: center;
 
     /* TODO: does not work correctly with tooltips around


### PR DESCRIPTION
The problem:
<img width="308" height="95" alt="Screenshot 2025-12-11 at 16 01 29" src="https://github.com/user-attachments/assets/41ffe17f-01be-4032-8675-c4b7f3bd6a93" />
